### PR TITLE
Introspection Query

### DIFF
--- a/src/EntityGraphQL/Compiler/GraphQLResultNode.cs
+++ b/src/EntityGraphQL/Compiler/GraphQLResultNode.cs
@@ -67,6 +67,12 @@ namespace EntityGraphQL.Compiler
                 var data = node.Execute(context);
                 result.Data[node.Name] = data;
             }
+
+            if (GraphQLVaildation.Errors.Count > 0)
+            {
+                result.Errors.AddRange(GraphQLVaildation.Errors);
+            }
+            
             return result;
         }
     }

--- a/src/EntityGraphQL/EntityQueryExtensions.cs
+++ b/src/EntityGraphQL/EntityQueryExtensions.cs
@@ -55,6 +55,7 @@ namespace EntityGraphQL
 
             try
             {
+                GraphQLVaildation.Errors = new List<GraphQLError>(); //Clear existing errors
                 var graphQLCompiler = new GraphQLCompiler(schemaProvider, methodProvider);
                 var queryResult = (GraphQLResultNode)graphQLCompiler.Compile(request);
                 result = queryResult.ExecuteQuery(context, request.OperationName);

--- a/src/EntityGraphQL/GraphQLVaildation.cs
+++ b/src/EntityGraphQL/GraphQLVaildation.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL
+{
+    internal static class GraphQLVaildation
+    {
+        public static List<GraphQLError> Errors { get; set; } = new List<GraphQLError>();
+    }
+}

--- a/src/EntityGraphQL/Schema/GraphQLIgnoreInputAttribute.cs
+++ b/src/EntityGraphQL/Schema/GraphQLIgnoreInputAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL.Schema
+{
+    /// <summary>
+    /// Tell the Introspection INPUT Schema to ignore this field or property
+    /// </summary>
+    public class GraphQLIgnoreInputAttribute : Attribute
+    {
+        public GraphQLIgnoreInputAttribute() { }
+    }
+}

--- a/src/EntityGraphQL/Schema/MappedSchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/MappedSchemaProvider.cs
@@ -461,5 +461,23 @@ namespace EntityGraphQL.Schema
         {
             return _mutations.Values.ToList();
         }
+
+        /// <summary>
+        /// Add a graphql error
+        /// </summary>
+        /// <param name="message"></param>
+        public void AddError(string message)
+        {
+            GraphQLVaildation.Errors.Add(new GraphQLError(message));
+        }
+
+        /// <summary>
+        /// Check if any GraphQL vaildation error
+        /// </summary>
+        /// <returns></returns>
+        public bool IsVaild()
+        {
+            return GraphQLVaildation.Errors.Count == 0;
+        }
     }
 }

--- a/src/EntityGraphQL/Schema/MappedSchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/MappedSchemaProvider.cs
@@ -438,6 +438,15 @@ namespace EntityGraphQL.Schema
             return SchemaGenerator.Make(this, _typeMappingForSchemaGeneration);
         }
 
+        /// <summary>
+        /// Builds a GraphQL Introspection schema
+        /// </summary>
+        /// <returns></returns>
+        public Models.Introspection GetGraphQLIntrospectionSchema()
+        {
+            return SchemaIntrospection.Make(this, _typeMappingForSchemaGeneration);
+        }
+
         public IEnumerable<Field> GetQueryFields()
         {
             return _types[_queryContextName].GetFields();

--- a/src/EntityGraphQL/Schema/Models/Introspection.cs
+++ b/src/EntityGraphQL/Schema/Models/Introspection.cs
@@ -82,7 +82,7 @@ namespace EntityGraphQL.Schema.Models
         public object[] Interfaces { get; set; }
 
         [JsonProperty("enumValues")]
-        public object EnumValues { get; set; }
+        public EnumValue[] EnumValues { get; set; }
 
         [JsonProperty("possibleTypes")]
         public object PossibleTypes { get; set; }
@@ -149,6 +149,21 @@ namespace EntityGraphQL.Schema.Models
 
         [JsonProperty("args")]
         public Arg[] Args { get; set; }
+    }
+
+    public partial class EnumValue
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("isDeprecated")]
+        public bool IsDeprecated { get; set; }
+
+        [JsonProperty("deprecationReason")]
+        public object DeprecationReason { get; set; }
     }
 
 

--- a/src/EntityGraphQL/Schema/Models/Introspection.cs
+++ b/src/EntityGraphQL/Schema/Models/Introspection.cs
@@ -1,0 +1,180 @@
+﻿//
+// Built using quicktype
+// https://app.quicktype.io/#l=cs&r=json2csharp
+//
+namespace EntityGraphQL.Schema.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    public partial class Introspection
+    {
+        [JsonProperty("errors")]
+        public object[] Errors { get; set; }
+
+        [JsonProperty("data")]
+        public Data Data { get; set; }
+    }
+
+    public partial class Data
+    {
+        [JsonProperty("__schema")]
+        public Schema Schema { get; set; }
+    }
+
+    public partial class Schema
+    {
+        [JsonProperty("queryType")]
+        public QueryType QueryType { get; set; }
+
+        [JsonProperty("mutationType")]
+        public MutationType MutationType { get; set; }
+
+        [JsonProperty("subscriptionType")]
+        public SubscriptionType SubscriptionType { get; set; }
+
+        [JsonProperty("types")]
+        public TypeElement[] Types { get; set; }
+
+        [JsonProperty("directives")]
+        public Directives[] Directives { get; set; }
+    }
+
+    public partial class QueryType
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public partial class MutationType
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public partial class SubscriptionType
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public partial class TypeElement
+    {
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("fields")]
+        public Field[] Fields { get; set; }
+
+        [JsonProperty("inputFields")]
+        public object InputFields { get; set; }
+
+        [JsonProperty("interfaces")]
+        public object[] Interfaces { get; set; }
+
+        [JsonProperty("enumValues")]
+        public object EnumValues { get; set; }
+
+        [JsonProperty("possibleTypes")]
+        public object PossibleTypes { get; set; }
+    }
+
+    public partial class Field
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("args")]
+        public Arg[] Args { get; set; }
+
+        [JsonProperty("type")]
+        public Type Type { get; set; }
+
+        [JsonProperty("isDeprecated")]
+        public bool IsDeprecated { get; set; }
+
+        [JsonProperty("deprecationReason")]
+        public object DeprecationReason { get; set; }
+    }
+
+    public partial class Arg
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public object Description { get; set; }
+
+        [JsonProperty("type")]
+        public Type Type { get; set; }
+
+        [JsonProperty("defaultValue")]
+        public object DefaultValue { get; set; }
+    }
+
+    public partial class Type
+    {
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("ofType")]
+        public Type OfType { get; set; }
+    }
+
+    public partial class Directives
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public object Description { get; set; }
+
+        [JsonProperty("locations")]
+        public string[] Locations { get; set; }
+
+        [JsonProperty("args")]
+        public Arg[] Args { get; set; }
+    }
+
+
+
+
+
+    public partial class Introspection
+    {
+        public static Introspection FromJson(string json) => JsonConvert.DeserializeObject<Introspection>(json, Converter.Settings);
+    }
+
+    public static class Serialize
+    {
+        public static string ToJson(this Introspection self) => JsonConvert.SerializeObject(self, Converter.Settings);
+    }
+
+    internal static class Converter
+    {
+        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+            DateParseHandling = DateParseHandling.None,
+            Converters =
+            {
+                new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
+            },
+        };
+    }
+}

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -106,8 +106,15 @@ namespace EntityGraphQL.Schema
                 {
                     continue;
                 }
+
+                //Get Description from ComponentModel.DescriptionAttribute
+                string description = "";
+                var d = (System.ComponentModel.DescriptionAttribute)prop.GetCustomAttribute(typeof(System.ComponentModel.DescriptionAttribute), false);
+                if (d != null)
+                    description = d.Description;
+
                 LambdaExpression le = Expression.Lambda(Expression.Property(param, prop.Name), param);
-                var f = new Field(prop.Name, le, "");
+                var f = new Field(prop.Name, le, description);
                 fields.Add(f);
                 CacheType<TContextType>(prop.PropertyType, schema);
             }

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -1,0 +1,420 @@
+﻿namespace EntityGraphQL.Schema
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using EntityGraphQL.Extensions;
+
+    public class SchemaIntrospection
+    {
+        private static readonly Dictionary<Type, string> defaultTypeMappings = new Dictionary<Type, string> {
+            {typeof(string), "String"},
+            {typeof(RequiredField<string>), "String"},
+            {typeof(Guid), "ID"},
+            {typeof(Guid?), "ID"},
+            {typeof(RequiredField<Guid>), "ID"},
+            {typeof(int), "Int"},
+            {typeof(RequiredField<int>), "Int"},
+            {typeof(int?), "Int"},
+            {typeof(double), "Float"},
+            {typeof(RequiredField<double>), "Float"},
+            {typeof(double?), "Float"},
+            {typeof(float), "Float"},
+            {typeof(RequiredField<float>), "Float"},
+            {typeof(float?), "Float"},
+            {typeof(bool), "Boolean"},
+            {typeof(bool?), "Boolean"},
+            {typeof(RequiredField<bool>), "Boolean"},
+            {typeof(EntityQueryType<>), "String"},
+            {typeof(RequiredField<long>), "Int"},
+            {typeof(long), "Int"},
+            {typeof(long?), "Int"},
+            {typeof(DateTime), "String"},
+            {typeof(DateTime?), "String"},
+            {typeof(RequiredField<DateTime>), "String"},
+        };
+
+        /// <summary>
+        /// Creates an Introspection schema
+        /// </summary>
+        /// <param name="schema"></param>
+        /// <param name="typeMappings"></param>
+        /// <returns></returns>
+        internal static Models.Introspection Make(ISchemaProvider schema, IReadOnlyDictionary<Type, string> typeMappings)
+        {
+            // defaults first
+            var combinedMapping = defaultTypeMappings.ToDictionary(k => k.Key, v => v.Value);
+            foreach (var item in typeMappings)
+            {
+                if (combinedMapping.ContainsKey(item.Key))
+                    combinedMapping[item.Key] = item.Value;
+                else
+                    combinedMapping.Add(item.Key, item.Value);
+            }
+
+            var types = new List<Models.TypeElement>
+            {
+                BuildRootQuery(schema, combinedMapping),
+                BuildMutationType(schema, combinedMapping)
+            };
+            types.AddRange(BuildQueryType(schema, combinedMapping));
+            types.AddRange(BuildInputType(schema, combinedMapping));
+
+            var introspection = new Models.Introspection
+            {
+                Data = new Models.Data
+                {
+                    Schema = new Models.Schema
+                    {
+                        QueryType = new Models.QueryType
+                        {
+                            Name = "RootQuery"
+                        },
+                        MutationType = new Models.MutationType
+                        {
+                            Name = "MutationQuery"
+                        },
+                        Types = types.OrderBy(x => x.Name).ToArray(),
+                        Directives = BuildDirectives().ToArray()
+                    }
+                }
+            };
+
+            return introspection;
+        }
+
+        private static Models.TypeElement BuildRootQuery(ISchemaProvider schema, IReadOnlyDictionary<Type, string> combinedMapping)
+        {
+            var rootFields = new List<Models.Field>();
+            var rootTypes = new Models.TypeElement
+            {
+                Kind = "OBJECT",
+                Name = "RootQuery",
+                Interfaces = new object[] { },
+                Fields = rootFields.ToArray(),
+                Description = "Queries available on this server."
+            };
+
+            foreach (var field in schema.GetQueryFields())
+            {
+                if (field.Name.StartsWith("__"))
+                    continue;
+
+                //== Arguments ==//
+                var args = new List<Models.Arg>();
+                foreach (var arg in field.Arguments)
+                {
+                    var type = new Models.Type();
+                    if (arg.Value.Name == "RequiredField`1")
+                    {
+                        type.Kind = "NON_NULL";
+                        type.Name = null;
+                        type.OfType = new Models.Type
+                        {
+                            Kind = "SCALAR",
+                            Name = FindNamedMapping(arg.Value, combinedMapping),
+                            OfType = null
+                        };
+                    }
+                    else
+                    {
+                        type.Kind = "SCALAR";
+                        type.Name = FindNamedMapping(arg.Value, combinedMapping);
+                        type.OfType = null;
+                    }
+
+                    args.Add(new Models.Arg
+                    {
+                        Name = arg.Key,
+                        Type = type
+                    });
+                }
+
+                //== Fields ==//
+                rootFields.Add(new Models.Field
+                {
+                    Name = field.Name,
+                    Args = args.ToArray(),
+                    IsDeprecated = false,
+                    Type = BuildType(field, combinedMapping),
+                    Description = field.Description
+                });
+            }
+
+            //add fields to base Root Query
+            rootTypes.Fields = rootFields.ToArray();
+
+            return rootTypes;
+        }
+
+        private static List<Models.TypeElement> BuildQueryType(ISchemaProvider schema, IReadOnlyDictionary<Type, string> combinedMapping)
+        {
+            var types = new List<Models.TypeElement>();
+
+            foreach (var st in schema.GetNonContextTypes())
+            {
+                var typeElement = new Models.TypeElement
+                {
+                    Kind = "OBJECT",
+                    Name = st.Name,
+                    Description = st.Description,
+                    Interfaces = new object[] { },
+                    Fields = new Models.Field[] { }
+                };
+
+                var fields = new List<Models.Field>();
+                foreach (var field in st.GetFields())
+                {
+                    if (field.Name.StartsWith("__"))
+                        continue;
+
+                    fields.Add(new Models.Field
+                    {
+                        Name = field.Name,
+                        Description = field.Description,
+                        IsDeprecated = false,
+                        Args = new Models.Arg[] { },
+                        Type = BuildType(field, combinedMapping)
+                    });
+                }
+
+                typeElement.Fields = fields.ToArray();
+                types.Add(typeElement);
+            }
+
+            return types;
+        }
+
+        /// <summary>
+        /// Build INPUT Type to be used by Mutations
+        /// </summary>
+        /// <param name="schema"></param>
+        /// <param name="combinedMapping"></param>
+        /// <remarks>
+        /// Since Types and Inputs cannot have the same name, camelCase the name to pervent duplicates.
+        /// </remarks>
+        /// <returns></returns>
+        private static List<Models.TypeElement> BuildInputType(ISchemaProvider schema, IReadOnlyDictionary<Type, string> combinedMapping)
+        {
+            var types = new List<Models.TypeElement>();
+
+            foreach (ISchemaType schemaType in schema.GetNonContextTypes())
+            {                
+                var typeElement = new Models.TypeElement
+                {
+                    Kind = "INPUT_OBJECT",
+                    Name = ToCamelCaseStartsLower(schemaType.Name),
+                    Description = schemaType.Description,
+                    Interfaces = new object[] { },
+                    Fields = null,
+                    InputFields = new Models.Field[] { }
+                };
+
+                var fields = new List<Models.Field>();
+                foreach (Field field in schemaType.GetFields())
+                {
+                    if (field.Name.StartsWith("__"))
+                        continue;
+
+                    //Skip any property with special attribute
+                    var property = schemaType.ContextType.GetProperty(field.Name);
+                    if (property != null && property.GetCustomAttribute(typeof(GraphQLIgnoreInputAttribute)) != null)
+                        continue;
+
+                    //Skipping custom fields added to schema
+                    if (field.Resolve.NodeType == System.Linq.Expressions.ExpressionType.Call)
+                        continue;
+
+                    fields.Add(new Models.Field
+                    {
+                        Name = field.Name,
+                        Description = field.Description,
+                        IsDeprecated = false,
+                        Args = new Models.Arg[] { },
+                        Type = BuildType(field, combinedMapping, true)
+                    });
+                }
+
+                typeElement.InputFields = fields.ToArray();
+                types.Add(typeElement);
+            }
+
+            return types;
+        }
+
+        private static Models.TypeElement BuildMutationType(ISchemaProvider schema, IReadOnlyDictionary<Type, string> combinedMapping)
+        {
+            var mutationTypes = new Models.TypeElement
+            {
+                Kind = "OBJECT",
+                Name = "MutationQuery",
+                Interfaces = new object[] { },
+                Description = "All mutations available on this server."
+            };
+            var mutationFields = new List<Models.Field>();
+
+            foreach (var mutation in schema.GetMutations())
+            {
+                if (mutation.Name.StartsWith("__"))
+                    continue;
+
+                /*== Arguments ==*/
+                var args = new List<Models.Arg>();
+                foreach (var arg in mutation.Arguments)
+                {
+                    //Skip any property with special attribute
+                    //Had to restore the PascalCase so Reflection could find it
+                    var propInfo = mutation.ReturnTypeClr.GetProperty(ToPascalCaseStartsUpper(arg.Key));
+                    if (propInfo != null && propInfo.GetCustomAttribute(typeof(GraphQLIgnoreInputAttribute)) != null)
+                        continue;
+
+                    var type = new Models.Type();
+                    if (arg.Value.Namespace.Contains("System.Collections.Generic"))
+                    {
+                        type.Kind = "LIST";
+                        type.Name = null;
+                        type.OfType = new Models.Type
+                        {
+                            Kind = "OBJECT",
+                            Name = ToCamelCaseStartsLower(arg.Value.GenericTypeArguments.First().Name),
+                            OfType = null
+                        };
+                    }
+                    else
+                    {
+                        type.Kind = combinedMapping.Any(x => x.Key == arg.Value) ? "SCALAR" : "OBJECT";
+                        type.Name = FindNamedMapping(arg.Value, combinedMapping, arg.Key);
+                    }
+
+                    args.Add(new Models.Arg
+                    {
+                        Name = arg.Key,
+                        Type = type
+                    });
+                }
+
+                /*== Fields ==*/
+                mutationFields.Add(new Models.Field
+                {
+                    Name = mutation.Name,
+                    Description = mutation.Description,
+                    Args = args.ToArray(),
+                    IsDeprecated = false,
+                    Type = new Models.Type
+                    {
+                        Kind = "OBJECT",
+                        Name = FindNamedMapping(mutation.ReturnTypeClr, combinedMapping, mutation.ReturnTypeClr.Name)
+                    }
+                });
+            }
+
+            mutationTypes.Fields = mutationFields.ToArray();
+            return mutationTypes;
+        }
+
+        private static Models.Type BuildType(Field field, IReadOnlyDictionary<Type, string> combinedMapping, bool isInput = false)
+        {
+            //Is collection of objects??
+            Models.Type type = new Models.Type();
+            if (field.IsEnumerable)
+            {
+                type.Kind = "LIST";
+                type.Name = null;
+                type.OfType = new Models.Type
+                {
+                    Kind = "OBJECT",
+                    Name = isInput ? ToCamelCaseStartsLower(field.ReturnTypeSingle) : field.ReturnTypeSingle
+                };
+            }
+            else
+            {
+                type.Kind = combinedMapping.Any(x => x.Key == field.ReturnTypeClr) ? "SCALAR" : "OBJECT";
+                if (type.Kind == "OBJECT" && isInput)
+                    type.Name = ToCamelCaseStartsLower(FindNamedMapping(field.ReturnTypeClr, combinedMapping, field.ReturnTypeSingle));
+                else
+                    type.Name = FindNamedMapping(field.ReturnTypeClr, combinedMapping, field.ReturnTypeSingle);
+            }
+
+            return type;
+        }
+
+        private static string FindNamedMapping(Type name, IReadOnlyDictionary<Type, string> combinedMapping, string fallback = null)
+        {
+            if (combinedMapping.Any(x => x.Key == name))
+                return combinedMapping[name];
+            else
+                if (string.IsNullOrEmpty(fallback))
+                    return name.ToString();
+                else
+                    return fallback;
+        }
+
+        public static string ToCamelCaseStartsLower(string name)
+        {
+            return name.Substring(0, 1).ToLowerInvariant() + name.Substring(1);
+        }
+
+        public static string ToPascalCaseStartsUpper(string name)
+        {
+            return name.Substring(0, 1).ToUpperInvariant() + name.Substring(1);
+        }
+
+        private static List<Models.Directives> BuildDirectives()
+        {
+            var directives = new List<Models.Directives> {
+                new Models.Directives
+                {
+                    Name = "include",
+                    Description = "Directs the executor to include this field or fragment only when the `if` argument is true.",
+                    Locations = new string[] { "FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT" },
+                    Args = new Models.Arg[] {
+                        new Models.Arg {
+                            Name = "if",
+                            Description = "Included when true.",
+                            DefaultValue = null,
+                            Type = new Models.Type
+                            {
+                                Kind = "NON_NULL",
+                                Name = null,
+                                OfType = new Models.Type
+                                {
+                                    Kind = "SCALAR",
+                                    Name = "Boolean",
+                                    OfType = null
+                                }
+                            }
+                        }
+                    }
+                },
+                new Models.Directives
+                {
+                    Name = "skip",
+                    Description = "Directs the executor to skip this field or fragment when the `if` argument is true.",
+                    Locations = new string[] { "FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT" },
+                    Args = new Models.Arg[] {
+                        new Models.Arg {
+                            Name = "if",
+                            Description = "Skipped when true.",
+                            DefaultValue = null,
+                            Type = new Models.Type
+                            {
+                                Kind = "NON_NULL",
+                                Name = null,
+                                OfType = new Models.Type
+                                {
+                                    Kind = "SCALAR",
+                                    Name = "Boolean",
+                                    OfType = null
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            return directives;
+        }
+    }
+}

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -282,11 +282,6 @@
                     if (field.Name.StartsWith("__"))
                         continue;
 
-                    //Skip any property with special attribute
-                    var property = schemaType.ContextType.GetProperty(field.Name);
-                    if (property != null && property.GetCustomAttribute(typeof(GraphQLIgnoreInputAttribute)) != null)
-                        continue;
-
                     ////Skipping custom fields added to schema
                     //if (field.Resolve.NodeType == System.Linq.Expressions.ExpressionType.Call)
                     //    continue;

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -125,16 +125,28 @@ namespace EntityGraphQL.Schema
             {
                 if (!_fieldsByName.ContainsKey(f.Name))
                 {
+                    //Get Description from ComponentModel.DescriptionAttribute
+                    string description = string.Empty;
+                    var d = (System.ComponentModel.DescriptionAttribute)f.GetCustomAttribute(typeof(System.ComponentModel.DescriptionAttribute), false);
+                    if (d != null)
+                        description = d.Description;
+
                     var parameter = Expression.Parameter(ContextType);
-                    this.AddField(new Field(f.Name, Expression.Lambda(Expression.Property(parameter, f.Name), parameter), string.Empty, string.Empty));
+                    this.AddField(new Field(f.Name, Expression.Lambda(Expression.Property(parameter, f.Name), parameter), description, null));
                 }
             }
             foreach (var f in ContextType.GetFields())
             {
                 if (!_fieldsByName.ContainsKey(f.Name))
                 {
+                    //Get Description from ComponentModel.DescriptionAttribute
+                    string description = string.Empty;
+                    var d = (System.ComponentModel.DescriptionAttribute)f.GetCustomAttribute(typeof(System.ComponentModel.DescriptionAttribute), false);
+                    if (d != null)
+                        description = d.Description;
+
                     var parameter = Expression.Parameter(ContextType);
-                    this.AddField(new Field(f.Name, Expression.Lambda(Expression.Field(parameter, f.Name), parameter), string.Empty, string.Empty));
+                    this.AddField(new Field(f.Name, Expression.Lambda(Expression.Field(parameter, f.Name), parameter), description, null));
                 }
             }
         }

--- a/src/demo/Controllers/QueryController.cs
+++ b/src/demo/Controllers/QueryController.cs
@@ -33,16 +33,27 @@ namespace demo.Controllers
 
         private object RunDataQuery(QueryRequest query)
         {
-
             try
             {
+                /* Operation name was missing from the default "IntrospectionQuery" in the graphiql.js file.
+                 * Manually added this ~approx line 2152 & 2168
+                 * Update both fetcher like so: var fetch = observableToPromise(fetcher({ query: _introspectionQueries.introspectionQuery, operationName: "IntrospectionQuery" }));
+                 */
+                if (!string.IsNullOrEmpty(query.OperationName)
+                    && (query.OperationName.Equals("IntrospectionQuery", StringComparison.InvariantCultureIgnoreCase)
+                    || query.Query.Contains("IntrospectionQuery", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    var introspection = _schemaProvider.GetGraphQLIntrospectionSchema();
+                    return introspection;
+                }
+
                 var data = _dbContext.QueryObject(query, _schemaProvider);
                 return data;
             }
-            catch (Exception)
-            {
-                return HttpStatusCode.InternalServerError;
+                catch (Exception)
+                {
+                    return HttpStatusCode.InternalServerError;
+                }
             }
-        }
     }
 }

--- a/src/demo/DemoContext.cs
+++ b/src/demo/DemoContext.cs
@@ -19,8 +19,11 @@ namespace demo
             builder.Entity<Person>().HasMany(p => p.WriterOf).WithOne(a => a.Person);
         }
 
+        [System.ComponentModel.Description("Collection of Movies")]
         public DbSet<Movie> Movies { get; set; }
+        [System.ComponentModel.Description("Collection of Peoples")]
         public DbSet<Person> People { get; set; }
+        [System.ComponentModel.Description("Collection of Actors")]
         public DbSet<Actor> Actors { get; set; }
     }
 
@@ -28,6 +31,8 @@ namespace demo
     {
         public uint Id { get; set; }
         public string Name { get; set; }
+
+        [System.ComponentModel.Description("Enum of Genre")]
         public Genre Genre { get; set; }
         public DateTime Released { get; set; }
         public List<Actor> Actors { get; set; }
@@ -54,10 +59,15 @@ namespace demo
 
     public enum Genre
     {
+        [System.ComponentModel.Description("Action movie type")]
         Action,
+        [System.ComponentModel.Description("Drama movie type")]
         Drama,
+        [System.ComponentModel.Description("Comedy movie type")]
         Comedy,
+        [System.ComponentModel.Description("Horror movie type")]
         Horror,
+        [System.ComponentModel.Description("Scifi movie type")]
         Scifi,
     }
 

--- a/src/demo/GraphQLSchema.cs
+++ b/src/demo/GraphQLSchema.cs
@@ -40,7 +40,7 @@ namespace demo
                 new { page = 1, pagesize = 10, search = "" },
                 (db, p) => PaginateActors(db, p),
                 "Pagination. [defaults: page = 1, pagesize = 10]",
-                "ActorPagination");
+                "PersonPagination");
 
             // add some mutations (always last, or after the types they require have been added)
             demoSchema.AddMutationFrom(new DemoMutations());


### PR DESCRIPTION
Start of Introspection Query. Summary of changes below. Copied of email for tracking.

- Add Models (folder) namespace to avoid collision with the Field object while working with Introspection return model.

- GraphQLIgnoreInputAttribute will remove the parameter from the INPUT type. Ex: might be to hide a virtual ICollection or navigation property.

- SchemaBuilder.cs: pull description from "ComponentModel.DescriptionAttribute".

- SchemaType.cs: pull description from "ComponentModel.DescriptionAttribute" & changed string.Empty to null. This will allow a new Field to update the ReturnTypeSingle.

- Update Demo with typos, descriptions, and checking for Introspection Query