### PR TITLE
split ignore into query and input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 0.21.1
+# 0.22.0
+- You can now specify if a field is ignored for queries, mutations or both (if you're sharing DTOs/objects)
 - Don't output the meta information of the schema in the schema definition
 - Prevent duplicate scalar types in schema generation
 

--- a/src/EntityGraphQL/Compiler/GraphQLMutationNode.cs
+++ b/src/EntityGraphQL/Compiler/GraphQLMutationNode.cs
@@ -45,7 +45,7 @@ namespace EntityGraphQL.Compiler
             // run the mutation to get the context for the query select
             var mutation = (MutationResult)this.result.ExpressionResult;
             var result = mutation.Execute(args);
-            if (result.GetType().GetTypeInfo().BaseType.GetTypeInfo().BaseType == typeof(LambdaExpression))
+            if (typeof(LambdaExpression).IsAssignableFrom(result.GetType()))
             {
                 var mutationLambda = (LambdaExpression)result;
                 var mutationContextParam = mutationLambda.Parameters.First();

--- a/src/EntityGraphQL/EntityGraphQL.csproj
+++ b/src/EntityGraphQL/EntityGraphQL.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>EntityGraphQL</AssemblyName>
     <PackageId>EntityGraphQL</PackageId>
-    <PackageVersion>0.21.0</PackageVersion>
+    <PackageVersion>0.22.0</PackageVersion>
     <Description>A GraphQL library for .NET Core. Compiles queries into .NET Expressions (LinqProvider) for runtime execution against object graphs. E.g. against an ORM data model (EntityFramework or others) or just an in-memory object.</Description>
     <Authors>Luke Murray</Authors>
     <PackageProjectUrl>https://github.com/lukemurray/EntityGraphQL</PackageProjectUrl>

--- a/src/EntityGraphQL/Schema/GraphQLIgnoreAttribute.cs
+++ b/src/EntityGraphQL/Schema/GraphQLIgnoreAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace EntityGraphQL.Schema
 {
@@ -7,5 +8,62 @@ namespace EntityGraphQL.Schema
     /// </summary>
     public class GraphQLIgnoreAttribute : Attribute
     {
+        public GraphQLIgnoreAttribute(GraphQLIgnoreType from = GraphQLIgnoreType.All)
+        {
+            IgnoreFrom = from;
+        }
+
+        public GraphQLIgnoreType IgnoreFrom { get; }
+
+        /// <summary>
+        /// Property is marked as being ignored for inclusion in the Query schema
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <returns></returns>
+        public static bool ShouldIgnoreMemberFromQuery(MemberInfo prop)
+        {
+            var attribute = prop.GetCustomAttribute(typeof(GraphQLIgnoreAttribute)) as GraphQLIgnoreAttribute;
+            if (attribute != null)
+            {
+                if (attribute.IgnoreFrom == GraphQLIgnoreType.All || attribute.IgnoreFrom == GraphQLIgnoreType.Query)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Property is marked as being ignored for inclusion in the Mutation Input types
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <returns></returns>
+        public static bool ShouldIgnoreMemberFromInput(MemberInfo prop)
+        {
+            var attribute = prop.GetCustomAttribute(typeof(GraphQLIgnoreAttribute)) as GraphQLIgnoreAttribute;
+            if (attribute != null)
+            {
+                if (attribute.IgnoreFrom == GraphQLIgnoreType.All || attribute.IgnoreFrom == GraphQLIgnoreType.Input)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    public enum GraphQLIgnoreType
+    {
+        /// <summary>
+        /// Ignored in generating the schema for Query
+        /// </summary>
+        Query,
+        /// <summary>
+        /// Ignored in generating/deserialising the input types
+        Input,
+        /// <summary>
+        /// Ignored completely by EntityGraphQL
+        /// </summary>
+        All,
     }
 }

--- a/src/EntityGraphQL/Schema/GraphQLMutationAttribute.cs
+++ b/src/EntityGraphQL/Schema/GraphQLMutationAttribute.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace EntityGraphQL.Schema
 {
+    /// <summary>
+    /// Marks the method in the class as a Mutation for EntityGraphQL to include in the Mutation Type.
+    /// You need to add the mutation to the schema using <code>schema.AddMutationFrom(new MyClass());</code>
+    /// </summary>
     public class GraphQLMutationAttribute : Attribute
     {
         public GraphQLMutationAttribute(string description = null)

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -84,16 +84,6 @@ namespace EntityGraphQL.Schema
             return argInstance;
         }
 
-        /// <summary>
-        /// Used at runtime below
-        /// </summary>
-        /// <param name="input"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        private static List<T> ConvertArray<T>(Array input)
-        {
-            return input.Cast<T>().ToList(); // Using LINQ for simplicity
-        }
 
         private object GetValue(Dictionary<string, ExpressionResult> gqlRequestArgs, string memberName, Type memberType)
         {
@@ -143,17 +133,16 @@ namespace EntityGraphQL.Schema
             this.argInstanceType = methodArg.ParameterType;
             foreach (var item in argInstanceType.GetProperties())
             {
+                if (GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(item))
+                    continue;
                 argumentTypes.Add(SchemaGenerator.ToCamelCaseStartsLower(item.Name), item.PropertyType);
             }
             foreach (var item in argInstanceType.GetFields())
             {
+                if (GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(item))
+                    continue;
                 argumentTypes.Add(SchemaGenerator.ToCamelCaseStartsLower(item.Name), item.FieldType);
             }
-        }
-
-        public Field GetField(string identifier)
-        {
-            return ReturnType.GetField(identifier);
         }
 
         public bool HasArgumentByName(string argName)

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -84,6 +84,16 @@ namespace EntityGraphQL.Schema
             return argInstance;
         }
 
+        /// <summary>
+        /// Used at runtime below
+        /// </summary>
+        /// <param name="input"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        private static List<T> ConvertArray<T>(Array input)
+        {
+            return input.Cast<T>().ToList(); // Using LINQ for simplicity
+        }
 
         private object GetValue(Dictionary<string, ExpressionResult> gqlRequestArgs, string memberName, Type memberType)
         {

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -101,7 +101,7 @@ namespace EntityGraphQL.Schema
 
             foreach (var prop in type.GetProperties())
             {
-                if (ignoreProps.Contains(prop.Name) || prop.GetCustomAttribute(typeof(GraphQLIgnoreAttribute)) != null)
+                if (ignoreProps.Contains(prop.Name) || GraphQLIgnoreAttribute.ShouldIgnoreMemberFromQuery(prop))
                 {
                     continue;
                 }

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -118,16 +118,16 @@
                     if (field.Name.StartsWith("__"))
                         continue;
 
-                    //Skip any property with special attribute
+                    // Skip any property with special attribute
                     var property = schemaType.ContextType.GetProperty(field.Name);
-                    if (property != null && property.GetCustomAttribute(typeof(GraphQLIgnoreAttribute)) != null)
+                    if (property != null && GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(property))
                         continue;
 
-                    //Skipping custom fields added to schema
+                    // Skipping custom fields added to schema
                     if (field.Resolve.NodeType == System.Linq.Expressions.ExpressionType.Call)
                         continue;
 
-                    //Skipping ENUM type
+                    // Skipping ENUM type
                     if (field.ReturnTypeClr.GetTypeInfo().IsEnum)
                         continue;
 

--- a/src/tests/EntityGraphQL.Tests/GraphQLIgnoreAttributeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/GraphQLIgnoreAttributeTests.cs
@@ -1,0 +1,168 @@
+using Xunit;
+using System.Linq;
+using EntityGraphQL.Schema;
+using System.Linq.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace EntityGraphQL.Tests
+{
+    /// <summary>
+    /// Tests graphql metadata
+    /// </summary>
+    public class GraphQLIgnoreAttributeTests
+    {
+        [Fact]
+        public void TestIgnoreQueryFails()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"query Test { movies { id } }",
+            };
+            dynamic results = new IgnoreTestSchema().QueryObject(gql, schemaProvider).Errors;
+            var err = Enumerable.First(results);
+            Assert.Equal("Error compiling query 'movies'. Field 'movies' not found on current context 'IgnoreTestSchema'", err.Message);
+        }
+        [Fact]
+        public void TestIgnoreQueryPasses()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"query Test { albums { id } }",
+            };
+            var results = new IgnoreTestSchema().QueryObject(gql, schemaProvider);
+            Assert.Empty(((IEnumerable)results.Data["albums"]));
+        }
+
+        [Fact]
+        public void TestIgnoreInputFails()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            schemaProvider.AddMutationFrom(new IgnoreTestMutations());
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"mutation Test($name: String, $hiddenInputField: String) {
+  addAlbum(name: $name, hiddenInputField: $hiddenInputField) {
+    id
+  }
+}",
+                Variables = new QueryVariables {
+                    {"name", "Balance, Not Symmetry"},
+                    {"hiddenInputField", "yeh"},
+                }
+            };
+            var results = new IgnoreTestSchema().QueryObject(gql, schemaProvider);
+            var error = results.Errors.First();
+            Assert.Equal("Error compiling query 'addAlbum(name: $name, hiddenInputField: $hiddenInputField)'. No argument 'hiddenInputField' found on field 'addAlbum'", error.Message);
+        }
+
+        [Fact]
+        public void TestIgnoreInputPasses()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            schemaProvider.AddMutationFrom(new IgnoreTestMutations());
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"mutation Test($name: String) {
+  addAlbum(name: $name) {
+    id name hiddenInputField
+  }
+}",
+                Variables = new QueryVariables {
+                    {"name", "Balance, Not Symmetry"},
+                }
+            };
+            var results = new IgnoreTestSchema().QueryObject(gql, schemaProvider);
+            dynamic data = results.Data["addAlbum"];
+            Assert.Equal("Balance, Not Symmetry", data.name);
+            Assert.Null(data.hiddenInputField); // not hidden from query
+            Assert.InRange(data.id, 0, 100);
+        }
+
+        [Fact]
+        public void TestIgnoreAllInInput()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            schemaProvider.AddMutationFrom(new IgnoreTestMutations());
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"mutation Test($name: String, $hiddenField: String) {
+  addAlbum(name: $name, hiddenField: $hiddenField) {
+    id
+  }
+}",
+                Variables = new QueryVariables {
+                    {"name", "Balance, Not Symmetry"},
+                    {"hiddenField", "yeh"},
+                }
+            };
+            var results = new IgnoreTestSchema().QueryObject(gql, schemaProvider);
+            var error = results.Errors.First();
+            Assert.Equal("Error compiling query 'addAlbum(name: $name, hiddenField: $hiddenField)'. No argument 'hiddenField' found on field 'addAlbum'", error.Message);
+        }
+
+        [Fact]
+        public void TestIgnoreAllInQuery()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"query Test {
+  albums {
+    id hiddenInputField hiddenField
+  }
+}",
+                Variables = new QueryVariables {}
+            };
+            var results = new IgnoreTestSchema().QueryObject(gql, schemaProvider);
+            var error = results.Errors.First();
+            Assert.Equal("Error compiling query 'albums'. Field 'hiddenField' not found on current context 'Album'", error.Message);
+        }
+    }
+
+    internal class IgnoreTestMutations
+    {
+        [GraphQLMutation]
+        public Expression<Func<IgnoreTestSchema, Album>> AddAlbum(IgnoreTestSchema db, Album args)
+        {
+            var newAlbum = new Album
+            {
+                Id = new Random().Next(100),
+                Name = args.Name,
+            };
+            db.Albums.Add(newAlbum);
+            return ctx => ctx.Albums.First(a => a.Id == newAlbum.Id);
+        }
+    }
+
+    internal class IgnoreTestSchema
+    {
+        public IgnoreTestSchema()
+        {
+            Movies = new List<Movie>();
+            Albums = new List<Album>();
+        }
+
+        [GraphQLIgnore(GraphQLIgnoreType.Query)]
+        public List<Movie> Movies { get; set; }
+        public List<Album> Albums { get; set; }
+    }
+
+    internal class Album
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        [GraphQLIgnore(GraphQLIgnoreType.Input)]
+        public string HiddenInputField { get; set; }
+        [GraphQLIgnore(GraphQLIgnoreType.All)] // default
+        public string HiddenAllField { get; set; }
+    }
+
+    internal class Movie
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/GraphQLIgnoreAttributeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/GraphQLIgnoreAttributeTests.cs
@@ -121,9 +121,22 @@ namespace EntityGraphQL.Tests
             var error = results.Errors.First();
             Assert.Equal("Error compiling query 'albums'. Field 'hiddenField' not found on current context 'Album'", error.Message);
         }
+
+        [Fact]
+        public void TestIgnoreWithSchema()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            schemaProvider.AddMutationFrom(new IgnoreTestMutations());
+            var schema = schemaProvider.GetGraphQLSchema();
+            Assert.DoesNotContain("hiddenField", schema);
+            // this exists as it is available for querying
+            Assert.Contains("type Album {\n\tid: Int\n\tname: String\n\thiddenInputField: String\n}", schema);
+            // doesn't include the hidden input fields
+            Assert.Contains("addAlbum(id: Int, name: String): Album", schema);
+        }
     }
 
-    internal class IgnoreTestMutations
+    public class IgnoreTestMutations
     {
         [GraphQLMutation]
         public Expression<Func<IgnoreTestSchema, Album>> AddAlbum(IgnoreTestSchema db, Album args)
@@ -138,7 +151,14 @@ namespace EntityGraphQL.Tests
         }
     }
 
-    internal class IgnoreTestSchema
+    public class MovieArgs
+    {
+        public string Name { get; set; }
+        [GraphQLIgnore(GraphQLIgnoreType.Input)]
+        public string Hidden { get; set; }
+    }
+
+    public class IgnoreTestSchema
     {
         public IgnoreTestSchema()
         {
@@ -151,7 +171,7 @@ namespace EntityGraphQL.Tests
         public List<Album> Albums { get; set; }
     }
 
-    internal class Album
+    public class Album
     {
         public int Id { get; set; }
         public string Name { get; set; }
@@ -161,7 +181,7 @@ namespace EntityGraphQL.Tests
         public string HiddenAllField { get; set; }
     }
 
-    internal class Movie
+    public class Movie
     {
         public int Id { get; set; }
     }

--- a/src/tests/EntityGraphQL.Tests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests.cs
@@ -72,7 +72,8 @@ namespace EntityGraphQL.Tests
                     {"names", new [] {"Bill", "Frank"}}
                 }
             };
-            dynamic addPersonResult = new TestSchema().QueryObject(gql, schemaProvider).Data;
+            var results = new TestSchema().QueryObject(gql, schemaProvider);
+            dynamic addPersonResult = results.Data;
             addPersonResult = Enumerable.First(addPersonResult);
             addPersonResult = addPersonResult.Value;
             // we only have the fields requested

--- a/src/tests/EntityGraphQL.Tests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests.cs
@@ -58,9 +58,6 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestSchema>(false);
             schemaProvider.AddMutationFrom(new PeopleMutations());
-            Expression<Func<TestSchema, object>> a = (TestSchema ts) => ts.People.Where(p => p.Id == 11).Select(p => new {
-                id = p.Id,
-            }).First();
             // Add a argument field with a require parameter
             var gql = new QueryRequest {
                 Query = @"mutation AddPerson($names: [String]) {
@@ -72,14 +69,15 @@ namespace EntityGraphQL.Tests
                     {"names", new [] {"Bill", "Frank"}}
                 }
             };
-            var results = new TestSchema().QueryObject(gql, schemaProvider);
+            var testSchema = new TestSchema();
+            var results = testSchema.QueryObject(gql, schemaProvider);
             dynamic addPersonResult = results.Data;
             addPersonResult = Enumerable.First(addPersonResult);
             addPersonResult = addPersonResult.Value;
             // we only have the fields requested
             Assert.Equal(3, addPersonResult.GetType().GetFields().Length);
             Assert.Equal("id", addPersonResult.GetType().GetFields()[0].Name);
-            Assert.Equal(0, addPersonResult.id);
+            Assert.Equal(11, addPersonResult.id);
             Assert.Equal("name", addPersonResult.GetType().GetFields()[1].Name);
             Assert.Equal("Bill", addPersonResult.name);
             Assert.Equal("Frank", addPersonResult.lastName);
@@ -118,8 +116,12 @@ namespace EntityGraphQL.Tests
 
     internal class TestSchema
     {
+        public TestSchema()
+        {
+            People = new List<Person> { new Person() };
+        }
         public string Hello { get { return "returned value"; } }
-        public List<Person> People { get { return new List<Person> { new Person() }; } }
+        public List<Person> People { get; set; }
         public IEnumerable<User> Users { get { return new List<User> { new User() }; } }
     }
 
@@ -152,7 +154,7 @@ namespace EntityGraphQL.Tests
         public Expression<Func<TestSchema, Person>> AddPersonNames(TestSchema db, PeopleMutationsArgs args)
         {
             db.People.Add(new Person { Id = 11, Name = args.Names[0], LastName = args.Names[1] });
-            return ctx => ctx.People.FirstOrDefault(p => p.Id == 11);
+            return ctx => ctx.People.First(p => p.Id == 11);
         }
 
         [GraphQLMutation]


### PR DESCRIPTION
fixes #20 

Use `[GraphQLIgnore]` to mark a field as ignored in both Input types and Query schema in EntityGraphQL.

Use `[GraphQLIgnore(GraphQLIgnoreType.Query)]` to mark a field as ignored in the query schema. If the type is also used in a mutation input type, the field is available.

Use `[GraphQLIgnore(GraphQLIgnoreType.Input)]` to ignore a field in a mutation input type if the type is also exposed in the query schema, it will be available.

Note `[GraphQLIgnore]` is shorthand for `[GraphQLIgnore(GraphQLIgnoreType.All)]`