### PR TITLE
Escape " in Description field when generating schema.

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaGenerator.cs
+++ b/src/EntityGraphQL/Schema/SchemaGenerator.cs
@@ -49,7 +49,7 @@ type RootQuery {{
             foreach (var item in schema.GetMutations())
             {
                 if (!string.IsNullOrEmpty(item.Description))
-                    mutations.AppendLine($"\t\"{item.Description}\"");
+                    mutations.AppendLine($"\t\"{item.Description.Replace("\"", "\\\"")}\"");
 
                 mutations.AppendLine($"\t{ToCamelCaseStartsLower(item.Name)}{GetGqlArgs(item, "()")}: {item.ReturnType.GqlTypeForReturnOrArgument}");
             }
@@ -67,7 +67,7 @@ type RootQuery {{
 
                 types.AppendLine();
                 if (!string.IsNullOrEmpty(typeItem.Description))
-                    types.AppendLine($"\t\"{typeItem.Description}\"");
+                    types.AppendLine($"\t\"{typeItem.Description.Replace("\"", "\\\"")}\"");
 
                 types.AppendLine($"enum {typeItem.Name} {{");
                 foreach (var field in typeItem.GetFields())
@@ -76,7 +76,7 @@ type RootQuery {{
                         continue;
 
                     if (!string.IsNullOrEmpty(field.Description))
-                        types.AppendLine($"\t\"{field.Description}\"");
+                        types.AppendLine($"\t\"{field.Description.Replace("\"", "\\\"")}\"");
 
                     types.AppendLine($"\t{field.Name}");
 
@@ -97,7 +97,7 @@ type RootQuery {{
 
                 types.AppendLine();
                 if (!string.IsNullOrEmpty(typeItem.Description))
-                    types.AppendLine($"\"{typeItem.Description}\"");
+                    types.AppendLine($"\"{typeItem.Description.Replace("\"", "\\\"")}\"");
 
                 types.AppendLine($"{(typeItem.IsInput ? "input" : "type")} {typeItem.Name} {{");
                 foreach (var field in typeItem.GetFields())
@@ -106,7 +106,7 @@ type RootQuery {{
                         continue;
 
                     if (!string.IsNullOrEmpty(field.Description))
-                        types.AppendLine($"\t\"{field.Description}\"");
+                        types.AppendLine($"\t\"{field.Description.Replace("\"", "\\\"")}\"");
 
                     types.AppendLine($"\t{ToCamelCaseStartsLower(field.Name)}{GetGqlArgs(field)}: {field.ReturnType.GqlTypeForReturnOrArgument}");
                 }
@@ -135,7 +135,7 @@ type RootQuery {{
                 if (t.Name.StartsWith("__"))
                     continue;
                 if (!string.IsNullOrEmpty(t.Description))
-                    sb.AppendLine($"\t\"{t.Description}\"");
+                    sb.AppendLine($"\t\"{t.Description.Replace("\"", "\\\"")}\"");
                 sb.AppendLine($"\t{ToCamelCaseStartsLower(t.Name)}{GetGqlArgs(t)}: {t.ReturnType.GqlTypeForReturnOrArgument}");
             }
 

--- a/src/EntityGraphQL/Schema/SchemaGenerator.cs
+++ b/src/EntityGraphQL/Schema/SchemaGenerator.cs
@@ -5,6 +5,11 @@ namespace EntityGraphQL.Schema
 {
     public class SchemaGenerator
     {
+        internal static string EscapeString(string input)
+        {
+            return input.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        }
+
         internal static string Make(ISchemaProvider schema)
         {
             var scalars = new StringBuilder();
@@ -49,7 +54,7 @@ type RootQuery {{
             foreach (var item in schema.GetMutations())
             {
                 if (!string.IsNullOrEmpty(item.Description))
-                    mutations.AppendLine($"\t\"{item.Description.Replace("\"", "\\\"")}\"");
+                    mutations.AppendLine($"\t\"{EscapeString(item.Description)}\"");
 
                 mutations.AppendLine($"\t{ToCamelCaseStartsLower(item.Name)}{GetGqlArgs(item, "()")}: {item.ReturnType.GqlTypeForReturnOrArgument}");
             }
@@ -67,7 +72,7 @@ type RootQuery {{
 
                 types.AppendLine();
                 if (!string.IsNullOrEmpty(typeItem.Description))
-                    types.AppendLine($"\t\"{typeItem.Description.Replace("\"", "\\\"")}\"");
+                    types.AppendLine($"\t\"{EscapeString(typeItem.Description)}\"");
 
                 types.AppendLine($"enum {typeItem.Name} {{");
                 foreach (var field in typeItem.GetFields())
@@ -76,7 +81,7 @@ type RootQuery {{
                         continue;
 
                     if (!string.IsNullOrEmpty(field.Description))
-                        types.AppendLine($"\t\"{field.Description.Replace("\"", "\\\"")}\"");
+                        types.AppendLine($"\t\"{EscapeString(field.Description)}\"");
 
                     types.AppendLine($"\t{field.Name}");
 
@@ -97,7 +102,7 @@ type RootQuery {{
 
                 types.AppendLine();
                 if (!string.IsNullOrEmpty(typeItem.Description))
-                    types.AppendLine($"\"{typeItem.Description.Replace("\"", "\\\"")}\"");
+                    types.AppendLine($"\"{EscapeString(typeItem.Description)}\"");
 
                 types.AppendLine($"{(typeItem.IsInput ? "input" : "type")} {typeItem.Name} {{");
                 foreach (var field in typeItem.GetFields())
@@ -106,7 +111,7 @@ type RootQuery {{
                         continue;
 
                     if (!string.IsNullOrEmpty(field.Description))
-                        types.AppendLine($"\t\"{field.Description.Replace("\"", "\\\"")}\"");
+                        types.AppendLine($"\t\"{EscapeString(field.Description)}\"");
 
                     types.AppendLine($"\t{ToCamelCaseStartsLower(field.Name)}{GetGqlArgs(field)}: {field.ReturnType.GqlTypeForReturnOrArgument}");
                 }
@@ -135,7 +140,7 @@ type RootQuery {{
                 if (t.Name.StartsWith("__"))
                     continue;
                 if (!string.IsNullOrEmpty(t.Description))
-                    sb.AppendLine($"\t\"{t.Description.Replace("\"", "\\\"")}\"");
+                    sb.AppendLine($"\t\"{EscapeString(t.Description)}\"");
                 sb.AppendLine($"\t{ToCamelCaseStartsLower(t.Name)}{GetGqlArgs(t)}: {t.ReturnType.GqlTypeForReturnOrArgument}");
             }
 


### PR DESCRIPTION
When the description contains a " the generated schema is invalid, this pull request replaces " with \\\" in the generated schema.