### PR TITLE
GetField by an expression

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -181,10 +181,10 @@ namespace EntityGraphQL.Schema
         /// Get a field by an expression selection on the real type. The name is changed to lowerCaseCamel
         /// </summary>
         /// <param name="fieldSelection"></param>
-        public void GetField(Expression<Func<TBaseType, object>> fieldSelection, ClaimsIdentity claims = null)
+        public Field GetField(Expression<Func<TBaseType, object>> fieldSelection, ClaimsIdentity claims = null)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(fieldSelection);
-            GetField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), claims);
+            return GetField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), claims);
         }
 
         public IEnumerable<Field> GetFields()

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -176,6 +176,16 @@ namespace EntityGraphQL.Schema
 
             throw new EntityGraphQLCompilerException($"Field {identifier} not found");
         }
+        
+        /// <summary>
+        /// Get a field by an expression selection on the real type. The name is changed to lowerCaseCamel
+        /// </summary>
+        /// <param name="fieldSelection"></param>
+        public void GetField(Expression<Func<TBaseType, object>> fieldSelection, ClaimsIdentity claims = null)
+        {
+            var exp = ExpressionUtil.CheckAndGetMemberExpression(fieldSelection);
+            GetField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), claims);
+        }
 
         public IEnumerable<Field> GetFields()
         {


### PR DESCRIPTION
Get a field by an expression selection on the real type.
A useful overload for the `GetField(string fieldName)` method. It takes an `Expression<Func<TBaseType, object>>` rather than a `string`.
It works just like the overload for the `RemoveField(string fieldName)` method, which currently exists, that method too takes an expression rather than a string and then does the work, which makes our lives easier.