### PR TITLE
Use FieldNamer instead of SchemaGenerator.ToCamelCaseStartsLower.

### DIFF
--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -12,6 +12,7 @@ namespace EntityGraphQL.Schema
 {
     public class MutationType : IField
     {
+        private readonly ISchemaProvider schema;
         private readonly object mutationClassInstance;
         private readonly MethodInfo method;
         private readonly Dictionary<string, ArgType> argumentTypes = new Dictionary<string, ArgType>();
@@ -90,7 +91,7 @@ namespace EntityGraphQL.Schema
                 var foundProp = false;
                 foreach (var prop in argType.GetProperties())
                 {
-                    var propName = SchemaGenerator.ToCamelCaseStartsLower(prop.Name);
+                    var propName = schema.SchemaFieldNamer(prop);
                     if (key == propName)
                     {
                         object value = GetValue(gqlRequestArgs, propName, prop.PropertyType);
@@ -102,7 +103,7 @@ namespace EntityGraphQL.Schema
                 {
                     foreach (var field in argType.GetFields())
                     {
-                        var fieldName = SchemaGenerator.ToCamelCaseStartsLower(field.Name);
+                        var fieldName = schema.SchemaFieldNamer(field);
                         if (key == fieldName)
                         {
                             object value = GetValue(gqlRequestArgs, fieldName, field.FieldType);
@@ -156,6 +157,7 @@ namespace EntityGraphQL.Schema
 
         public MutationType(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, object mutationClassInstance, MethodInfo method, string description, RequiredClaims authorizeClaims, bool isAsync, Func<MemberInfo, string> fieldNamer)
         {
+            this.schema = schema;
             Description = description;
             ReturnType = returnType;
             this.mutationClassInstance = mutationClassInstance;

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -210,7 +210,7 @@ namespace EntityGraphQL.Schema
                 if (method.GetCustomAttribute(typeof(GraphQLMutationAttribute)) is GraphQLMutationAttribute attribute)
                 {
                     var isAsync = method.GetCustomAttribute(typeof(AsyncStateMachineAttribute)) != null;
-                    string name = SchemaGenerator.ToCamelCaseStartsLower(method.Name);
+                    string name = this.SchemaFieldNamer(method);
                     var claims = method.GetCustomAttributes(typeof(GraphQLAuthorizeAttribute)).Cast<GraphQLAuthorizeAttribute>();
                     var requiredClaims = new RequiredClaims(claims);
                     var actualReturnType = GetTypeFromMutationReturn(isAsync ? method.ReturnType.GetGenericArguments()[0] : method.ReturnType);
@@ -278,7 +278,7 @@ namespace EntityGraphQL.Schema
         public Field AddField<TReturn>(Expression<Func<TContextType, TReturn>> selection, string description, string returnSchemaType = null)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(selection);
-            return AddField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), selection, description, returnSchemaType);
+            return AddField(this.SchemaFieldNamer(exp.Member), selection, description, returnSchemaType);
         }
 
         /// <summary>
@@ -297,7 +297,7 @@ namespace EntityGraphQL.Schema
         public Field ReplaceField<TParams, TReturn>(Expression<Func<TContextType, object>> selection, TParams argTypes, Expression<Func<TContextType, TParams, TReturn>> selectionExpression, string description, string returnSchemaType = null)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(selection);
-            var name = SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name);
+            var name = this.SchemaFieldNamer(exp.Member);
             Type<TContextType>().RemoveField(name);
             return Type<TContextType>().AddField(name, argTypes, selectionExpression, description, returnSchemaType);
         }

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -83,7 +83,7 @@ namespace EntityGraphQL.Schema
         public Field AddField<TReturn>(Expression<Func<TBaseType, TReturn>> fieldSelection, string description, string returnSchemaType = null)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(fieldSelection);
-            return AddField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), fieldSelection, description, returnSchemaType);
+            return AddField(this.schema.SchemaFieldNamer(exp.Member), fieldSelection, description, returnSchemaType);
         }
 
         public Field AddField(Field field)
@@ -220,7 +220,7 @@ namespace EntityGraphQL.Schema
         public Field GetField(Expression<Func<TBaseType, object>> fieldSelection, ClaimsIdentity claims = null)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(fieldSelection);
-            return GetField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name), claims);
+            return GetField(this.schema.SchemaFieldNamer(exp.Member), claims);
         }
 
         public IEnumerable<Field> GetFields()
@@ -251,7 +251,7 @@ namespace EntityGraphQL.Schema
         public void RemoveField(Expression<Func<TBaseType, object>> fieldSelection)
         {
             var exp = ExpressionUtil.CheckAndGetMemberExpression(fieldSelection);
-            RemoveField(SchemaGenerator.ToCamelCaseStartsLower(exp.Member.Name));
+            RemoveField(this.schema.SchemaFieldNamer(exp.Member));
         }
 
         /// <summary>


### PR DESCRIPTION
Currently the `ToCamelCaseStartsLower` is used in some cases and the `FieldNamer` in others, this desync causes errors for example with mutation arguments, giving the error that a field is not found.

I fixed all the easy ones in this pull request, but there are 5 left that don't operate on `MemberInfo` that i have no idea how to fix.

* SchemaGenerator.BuildMutations
* SchemaGenerator.BuildSchemaTypes
* SchemaGenerator.GetGqlArgs
* SchemaGenerator.MakeQueryType
* SchemaIntrospection.BuildFieldsForType