### PR TITLE
Added string and long parsing for DateTime and DateTimeOffset

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -65,7 +65,19 @@ namespace EntityGraphQL.Compiler.Util
                     return int.Parse((string)value);
                 if (type == typeof(uint) || type == typeof(Nullable<uint>))
                     return uint.Parse((string)value);
+                if (type == typeof(DateTime) || type == typeof(Nullable<DateTime>))
+                    return DateTime.Parse((string)value);
+                if (type == typeof(DateTimeOffset) || type == typeof(Nullable<DateTimeOffset>))
+                    return DateTimeOffset.Parse((string)value);
             }
+            else if (type != typeof(long) && objType == typeof(long))
+            {
+                if (type == typeof(DateTime) || type == typeof(Nullable<DateTime>))
+                    return new DateTime((long)value);
+                if (type == typeof(DateTimeOffset) || type == typeof(Nullable<DateTimeOffset>))
+                    return new DateTimeOffset((long)value, TimeSpan.Zero);
+            }
+
             var argumentNonNullType = type.IsNullableType() ? Nullable.GetUnderlyingType(type) : type;
             var valueNonNullType = objType.IsNullableType() ? Nullable.GetUnderlyingType(objType) : objType;
             if (argumentNonNullType.GetTypeInfo().IsEnum)


### PR DESCRIPTION
Added string and long parsing for DateTime and DateTimeOffset. In my particular use case, I had a field that accepted a `DateTimeOffset` as a parameter. This change allows for the ability to pass that parameter as either a formatted string, or ticks.

```
{
  entity(startDate: 637384711224902655, endDate: "2020-10-16T18:54:19.5109301-04:00") {
    id
    latitude
    longtitude
    address1
    city
    country
    postalCode
    state
  }
}
```