### PR TITLE
Update Humanizer.Core version

### DIFF
--- a/src/EntityGraphQL/EntityGraphQL.csproj
+++ b/src/EntityGraphQL/EntityGraphQL.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4" Version="4.6.6" />
     <PackageReference Include="Antlr4.Runtime" Version="4.6.6" />
-    <PackageReference Include="Humanizer.Core" Version="2.7.9" />
+    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />

--- a/src/tests/EntityGraphQL.Tests/EntityGraphQL.Tests.csproj
+++ b/src/tests/EntityGraphQL.Tests/EntityGraphQL.Tests.csproj
@@ -12,11 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/tests/EntityGraphQL.Tests/EntityGraphQL.Tests.csproj
+++ b/src/tests/EntityGraphQL.Tests/EntityGraphQL.Tests.csproj
@@ -12,7 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
Updated Humanizer.Core version because it conflicts with newer version from other packages, for example Microsoft.EntityFrameworkCore.Tools