### PR TITLE
Add full TimeSpan, DateOnly, and TimeOnly support (queries + mutations)

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityQuery/EqlMethodProvider.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/EqlMethodProvider.cs
@@ -227,8 +227,10 @@ public class EqlMethodProvider : IMethodProvider
             typeof(Guid),
             typeof(Guid?),
             typeof(DateTimeOffset),
-            typeof(DateTimeOffset?)
-#if NET5_0_OR_GREATER
+            typeof(DateTimeOffset?),
+            typeof(TimeSpan),
+            typeof(TimeSpan?)
+#if NET6_0_OR_GREATER
             ,
             typeof(DateOnly),
             typeof(DateOnly?),

--- a/src/EntityGraphQL/Compiler/EntityQuery/Grammar/Binary.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/Grammar/Binary.cs
@@ -59,6 +59,20 @@ internal sealed class Binary(ExpressionType op, IExpression left, IExpression ri
                 right = ConvertToDateTimeOffset(right);
             else if (right.Type == typeof(DateTimeOffset) || right.Type == typeof(DateTimeOffset?) && left.Type == typeof(string))
                 left = ConvertToDateTimeOffset(left);
+            else if (left.Type == typeof(TimeSpan) || left.Type == typeof(TimeSpan?) && right.Type == typeof(string))
+                right = ConvertToTimeSpan(right);
+            else if (right.Type == typeof(TimeSpan) || right.Type == typeof(TimeSpan?) && left.Type == typeof(string))
+                left = ConvertToTimeSpan(left);
+#if NET6_0_OR_GREATER
+            else if (left.Type == typeof(DateOnly) || left.Type == typeof(DateOnly?) && right.Type == typeof(string))
+                right = ConvertToDateOnly(right);
+            else if (right.Type == typeof(DateOnly) || right.Type == typeof(DateOnly?) && left.Type == typeof(string))
+                left = ConvertToDateOnly(left);
+            else if (left.Type == typeof(TimeOnly) || left.Type == typeof(TimeOnly?) && right.Type == typeof(string))
+                right = ConvertToTimeOnly(right);
+            else if (right.Type == typeof(TimeOnly) || right.Type == typeof(TimeOnly?) && left.Type == typeof(string))
+                left = ConvertToTimeOnly(left);
+#endif
             else if (left.Type.IsEnum && right.Type == typeof(string))
                 right = ConvertToEnum(right, left.Type);
             else if (right.Type.IsEnum && left.Type == typeof(string))
@@ -95,6 +109,23 @@ internal sealed class Binary(ExpressionType op, IExpression left, IExpression ri
     {
         return Expression.Call(typeof(DateTime), nameof(DateTime.Parse), null, expression, Expression.Constant(CultureInfo.InvariantCulture));
     }
+
+    private static MethodCallExpression ConvertToTimeSpan(Expression expression)
+    {
+        return Expression.Call(typeof(TimeSpan), nameof(TimeSpan.Parse), null, expression, Expression.Constant(CultureInfo.InvariantCulture));
+    }
+
+#if NET6_0_OR_GREATER
+    private static MethodCallExpression ConvertToDateOnly(Expression expression)
+    {
+        return Expression.Call(typeof(DateOnly), nameof(DateOnly.Parse), null, expression, Expression.Constant(CultureInfo.InvariantCulture));
+    }
+
+    private static MethodCallExpression ConvertToTimeOnly(Expression expression)
+    {
+        return Expression.Call(typeof(TimeOnly), nameof(TimeOnly.Parse), null, expression, Expression.Constant(CultureInfo.InvariantCulture));
+    }
+#endif
 
     private static MethodCallExpression ConvertToGuid(Expression expression)
     {

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -169,6 +169,14 @@ public static class ExpressionUtil
                 return DateTime.Parse((string)value, CultureInfo.InvariantCulture);
             if (toType == typeof(DateTimeOffset) || toType == typeof(DateTimeOffset?))
                 return DateTimeOffset.Parse((string)value, CultureInfo.InvariantCulture);
+            if (toType == typeof(TimeSpan) || toType == typeof(TimeSpan?))
+                return TimeSpan.Parse((string)value, CultureInfo.InvariantCulture);
+#if NET6_0_OR_GREATER
+            if (toType == typeof(DateOnly) || toType == typeof(DateOnly?))
+                return DateOnly.Parse((string)value, CultureInfo.InvariantCulture);
+            if (toType == typeof(TimeOnly) || toType == typeof(TimeOnly?))
+                return TimeOnly.Parse((string)value, CultureInfo.InvariantCulture);
+#endif
         }
         else if (toType != typeof(long) && fromType == typeof(long))
         {
@@ -176,6 +184,14 @@ public static class ExpressionUtil
                 return new DateTime((long)value);
             if (toType == typeof(DateTimeOffset) || toType == typeof(DateTimeOffset?))
                 return new DateTimeOffset((long)value, TimeSpan.Zero);
+            if (toType == typeof(TimeSpan) || toType == typeof(TimeSpan?))
+                return new TimeSpan((long)value);
+#if NET6_0_OR_GREATER
+            if (toType == typeof(DateOnly) || toType == typeof(DateOnly?))
+                return DateOnly.FromDateTime(new DateTime((long)value));
+            if (toType == typeof(TimeOnly) || toType == typeof(TimeOnly?))
+                return TimeOnly.FromTimeSpan(new TimeSpan((long)value));
+#endif
         }
 
         var argumentNonNullType = toType.IsNullableType() ? Nullable.GetUnderlyingType(toType)! : toType;

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -88,6 +88,9 @@ public class SchemaProvider<TContextType> : ISchemaProvider, IDisposable
         // TODO 6.0 - Rename Date to DateTime?
         AddScalarType<DateTime>("Date", "Date with time scalar");
         AddScalarType<DateTimeOffset>("DateTimeOffset", "DateTimeOffset scalar");
+        
+        // default custom scalar for TimeSpan
+        AddScalarType<TimeSpan>("TimeSpan", "TimeSpan scalar");
 #if NET6_0_OR_GREATER
         AddScalarType<DateOnly>("DateOnly", "Date value only scalar");
         AddScalarType<TimeOnly>("TimeOnly", "Time value only scalar");

--- a/src/tests/EntityGraphQL.Tests/DateAndTimeScalarsTests.cs
+++ b/src/tests/EntityGraphQL.Tests/DateAndTimeScalarsTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using EntityGraphQL.Compiler.EntityQuery;
+using EntityGraphQL.Compiler;
+using Microsoft.Extensions.DependencyInjection;
+using EntityGraphQL.Schema;
+using Xunit;
+
+namespace EntityGraphQL.Tests;
+
+public class DateAndTimeScalarsTests
+{
+    private readonly EqlCompileContext compileContext = new(new CompileContext(new ExecutionOptions(), null, new QueryRequestContext(null, null), null, null));
+
+#if NET6_0_OR_GREATER
+    private class WithDateOnly
+    {
+        public WithDateOnly(DateOnly d, string name)
+        {
+            D = d;
+            Name = name;
+        }
+        public DateOnly D { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Theory]
+    [InlineData("\"2020-08-11\"")]
+    public void EntityQuery_WorksWithDateOnly(string dateValue)
+    {
+        var schemaProvider = SchemaBuilder.FromObject<WithDateOnly>();
+        var compiled = EntityQueryCompiler.Compile($"d >= {dateValue}", schemaProvider, compileContext);
+        var list = new List<WithDateOnly>
+        {
+            new(new DateOnly(2020, 08, 10), "First"),
+            new(new DateOnly(2020, 08, 11), "Second"),
+            new(new DateOnly(2020, 08, 12), "Third"),
+        };
+        var res = list.Where((Func<WithDateOnly, bool>)compiled.LambdaExpression.Compile()).ToList();
+        Assert.Equal(2, res.Count);
+        Assert.Equal("Second", res[0].Name);
+        Assert.Equal("Third", res[1].Name);
+    }
+
+    private class WithTimeOnly
+    {
+        public WithTimeOnly(TimeOnly t, string name)
+        {
+            T = t;
+            Name = name;
+        }
+        public TimeOnly T { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Theory]
+    [InlineData("\"13:22:11\"", 2)]
+    [InlineData("\"13:22:11.3000003\"", 1)]
+    public void EntityQuery_WorksWithTimeOnly(string timeValue, int expectedCount)
+    {
+        var schemaProvider = SchemaBuilder.FromObject<WithTimeOnly>();
+        var compiled = EntityQueryCompiler.Compile($"t >= {timeValue}", schemaProvider, compileContext);
+        var list = new List<WithTimeOnly>
+        {
+            new(new TimeOnly(13, 21, 11), "First"),
+            new(new TimeOnly(13, 22, 11), "Second"),
+            new(new TimeOnly(13, 23, 11), "Third"),
+        };
+        var res = list.Where((Func<WithTimeOnly, bool>)compiled.LambdaExpression.Compile()).ToList();
+        Assert.Equal(expectedCount, res.Count);
+        Assert.Equal(res.Last().Name, expectedCount == 2 ? "Third" : "Third");
+    }
+#endif
+
+    private class WithTimeSpan
+    {
+        public WithTimeSpan(TimeSpan span, string name)
+        {
+            Span = span;
+            Name = name;
+        }
+        public TimeSpan Span { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Theory]
+    [InlineData("\"01:02:03\"", 2)]
+    [InlineData("\"00:00:00\"", 3)]
+    public void EntityQuery_WorksWithTimeSpan(string spanValue, int expectedCount)
+    {
+        var schemaProvider = SchemaBuilder.FromObject<WithTimeSpan>();
+        var compiled = EntityQueryCompiler.Compile($"span >= {spanValue}", schemaProvider, compileContext);
+        var list = new List<WithTimeSpan>
+        {
+            new(TimeSpan.FromHours(1), "First"),
+            new(new TimeSpan(1, 2, 3), "Second"),
+            new(new TimeSpan(3, 0, 0), "Third"),
+        };
+        var res = list.Where((Func<WithTimeSpan, bool>)compiled.LambdaExpression.Compile()).ToList();
+        Assert.Equal(expectedCount, res.Count);
+    }
+
+#if NET6_0_OR_GREATER
+    private class MutationContext { }
+
+    private class EchoTypes
+    {
+        [GraphQLMutation]
+        public EchoResult Echo(DateOnly d, TimeOnly t, TimeSpan span)
+        {
+            return new EchoResult { D = d, T = t, Span = span };
+        }
+    }
+
+    private class EchoResult
+    {
+        public DateOnly D { get; set; }
+        public TimeOnly T { get; set; }
+        public TimeSpan Span { get; set; }
+    }
+
+    [Fact]
+    public void Mutation_Deserializes_DateOnly_TimeOnly_TimeSpan()
+    {
+        var schema = new SchemaProvider<MutationContext>();
+        schema.AddType<EchoResult>(nameof(EchoResult), null).AddAllFields();
+        schema.AddMutationsFrom<EchoTypes>(new SchemaBuilderOptions { AutoCreateInputTypes = true });
+
+        var req = new QueryRequest
+        {
+            Query = @"mutation m { echo(d: ""2020-08-11"", t: ""13:22:11"", span: ""01:02:03"") { d t span } }",
+        };
+
+        var result = schema.ExecuteRequestWithContext(req, new MutationContext(), null, null);
+        Assert.Null(result.Errors);
+    }
+#endif
+}


### PR DESCRIPTION
### Summary
- Adds `TimeSpan` as a default scalar.
- Completes `DateOnly` and `TimeOnly` handling (NET 6+) for query filters and mutation/variable deserialization.
- Ensures mixed-type comparisons (e.g., CLR type vs. string literal) compile and execute correctly.
- Adds tests for these scalars.

### Motivation
Users can already work with `DateTime` and `DateTimeOffset`. However, `TimeSpan` was missing as a built-in scalar, and `DateOnly`/`TimeOnly` support was incomplete. Here, the following is added:
- Filters like `TimeSpan >= "01:02:03"`, `DateOnly == "2020-08-11"`, and `TimeOnly < "13:22:11"` work in EntityQuery.
- Mutation arguments/variables for these types (typically provided as strings in JSON) are deserialized to CLR types without custom glue code.

### What’s changed
- Compiler/EntityQuery/Grammar/`Binary.cs`
  - Added conversions from string literals to CLR types when left/right types differ:
    - `TimeSpan`
    - `DateOnly` and `TimeOnly` (under `NET6_0_OR_GREATER`)
  - Implemented helper methods:
    - `ConvertToTimeSpan`
    - `ConvertToDateOnly` (NET 6+)
    - `ConvertToTimeOnly` (NET 6+)
  - Uses `CultureInfo.InvariantCulture`, mirroring existing `DateTime`/`DateTimeOffset` logic.

- Compiler/EntityQuery/`EqlMethodProvider.cs`
  - Updated `isAny` type predicate to include `TimeSpan` and aligned `DateOnly`/`TimeOnly` under `#if NET6_0_OR_GREATER` (was `NET5_0_OR_GREATER`). Ensures methods gated by scalar support (like `isAny`) recognize these types only when available.

- Compiler/Util/`ExpressionUtil.cs`
  - Added string → CLR conversions for `TimeSpan`, `DateOnly`, `TimeOnly` and long(ticks) → CLR conversions.

- Schema/`SchemaProvider.cs`
  - Registers `TimeSpan` as a default scalar via `AddScalarType<TimeSpan>("TimeSpan", ...)` alongside existing defaults.
  - `DateOnly` and `TimeOnly` remain registered for NET 6+.

- Tests/`DateAndTimeScalarsTests.cs` (new)
  - Query-time filters:
    - `TimeSpan` comparisons from string literals.
    - (NET 6+) `DateOnly` and `TimeOnly` comparisons from string literals.
  - Mutation-time deserialization (NET 6+):
    - A mutation accepting `DateOnly`, `TimeOnly`, and `TimeSpan` arguments provided as strings executes without errors.

### Parsing formats
- `TimeSpan`: `TimeSpan.Parse(..., InvariantCulture)` e.g., `"hh:mm:ss"` (fractional seconds allowed).
- `DateOnly` (NET 6+): `DateOnly.Parse(..., InvariantCulture)` e.g., `"yyyy-MM-dd"`.
- `TimeOnly` (NET 6+): `TimeOnly.Parse(..., InvariantCulture)` e.g., `"HH:mm:ss[.fffffff]"`.

### Files modified
- `src/EntityGraphQL/Compiler/EntityQuery/Grammar/Binary.cs`
- `src/EntityGraphQL/Compiler/EntityQuery/EqlMethodProvider.cs`
- `src/EntityGraphQL/Schema/SchemaProvider.cs`
- Added tests: `src/tests/EntityGraphQL.Tests/DateAndTimeScalarsTests.cs`

### Potential edge cases and notes
- `DateTime.Parse` with offsets converts to local time; this is consistent with existing behavior and tested elsewhere (see `EntityQueryCompilerTests`).
- Consumers can still register custom converters if they prefer different parsing rules or formats.