### PR TITLE
Pass docvariables through to directives so they can use arguments

### DIFF
--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
@@ -27,7 +27,7 @@ public class GraphQLQueryStatement : ExecutableGraphQLStatement
         // apply directives
         foreach (var directive in field.Directives)
         {
-            if (directive.VisitNode(ExecutableDirectiveLocation.Field, Schema, field, Arguments, null, null) == null)
+            if (directive.VisitNode(ExecutableDirectiveLocation.Field, Schema, field, Arguments, OpVariableParameter, docVariables) == null)
                 return (null, false, []);
         }
         (var data, var didExecute) = await CompileAndExecuteNodeAsync(compileContext, context!, serviceProvider, fragments, field, docVariables);

--- a/src/tests/EntityGraphQL.Tests/QueryTests/DirectiveTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/DirectiveTests.cs
@@ -286,6 +286,59 @@ public class DirectiveTests
         Assert.Empty(result.Data);
     }
 
+    /// <summary>
+    /// Root-level field with @include(if: $var) where var=true — the field should appear in results.
+    /// Without the fix (passing null,null to VisitNode in GraphQLQueryStatement), variable resolution
+    /// fails with "Variable or value used for argument 'if' does not match argument type 'Boolean!'".
+    /// </summary>
+    [Fact]
+    public void TestIncludeDirectiveVariableOnRootField()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        var query = new QueryRequest
+        {
+            Query =
+                @"query MyQuery($include: Boolean!) {
+                    people @include(if: $include) {
+                        id
+                        name
+                    }
+                }",
+            Variables = new QueryVariables { { "include", true } },
+        };
+        var result = schema.ExecuteRequestWithContext(query, new TestDataContext().FillWithTestData(), null, null, null);
+        Assert.Null(result.Errors);
+        Assert.NotNull(result.Data);
+        Assert.NotEmpty(result.Data);
+    }
+
+    /// <summary>
+    /// Root-level field with @skip(if: $var) where var=false — the field should appear in results.
+    /// Without the fix, the same variable resolution failure occurs because Expand() only filters
+    /// fields when the directive says to skip; when the field is kept, ExecuteOperationField still
+    /// calls VisitNode with null docVariables.
+    /// </summary>
+    [Fact]
+    public void TestSkipDirectiveVariableFalseOnRootField()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        var query = new QueryRequest
+        {
+            Query =
+                @"query MyQuery($skip: Boolean!) {
+                    people @skip(if: $skip) {
+                        id
+                        name
+                    }
+                }",
+            Variables = new QueryVariables { { "skip", false } },
+        };
+        var result = schema.ExecuteRequestWithContext(query, new TestDataContext().FillWithTestData(), null, null, null);
+        Assert.Null(result.Errors);
+        Assert.NotNull(result.Data);
+        Assert.NotEmpty(result.Data);
+    }
+
     [Fact]
     public void TestDirectiveInSchemaOutputWithArgs()
     {


### PR DESCRIPTION
Seeing exceptions when using 'include' directive in v6.

"Variable or value used for argument 'if' does not match argument type 'Boolean!' on field 'include'"